### PR TITLE
Fix warning when running tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php">
 
     <testsuite name="DB Writer Common Test Suite">


### PR DESCRIPTION
proposed changes: remove deprecated syntaxCheck property